### PR TITLE
chore: add mise config for Node, Bun, and Supabase

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,7 @@
+# VizzoCheck - mise configuration
+# Install with: mise install
+
+[tools]
+node = "20"
+bun = "latest"
+supabase = "latest"


### PR DESCRIPTION
Add `.mise.toml` for development setup with Node 20, Bun, and Supabase CLI.

https://mise.jdx.dev/