### PR TITLE
feat: Admin geral vs Agência (Issue #1)

### DIFF
--- a/IMPLEMENTATION_STATUS.md
+++ b/IMPLEMENTATION_STATUS.md
@@ -6,6 +6,7 @@
 
 - ✅ **Backend API**: 100% Complete - All endpoints implemented and tested
 - ✅ **Admin Dashboard**: 100% Complete - All pages and features implemented
+- ✅ **Admin geral vs Agência (Issue #1)**: Implemented — papéis system_admin e agency; escopo cross-agency para admin geral; ver [docs/roles-and-scope.md](docs/roles-and-scope.md)
 - ✅ **Promoter PWA**: ~95% Complete - All core pages implemented, minor enhancements pending
 - 🚧 **PWA Features**: ~30% Complete - Manifest configured, service worker and camera API pending
 
@@ -22,7 +23,8 @@
 
 ### Backend API
 - ✅ Authentication (register, login, JWT)
-- ✅ Agency management
+- ✅ **Roles: system_admin and agency** — Admin geral (cross-agency) vs Agência (escopo restrito); ver [docs/roles-and-scope.md](docs/roles-and-scope.md)
+- ✅ Agency management (list agencies for system_admin; get agency for agency/system_admin)
 - ✅ Promoter CRUD operations
 - ✅ Brand CRUD operations
 - ✅ Store CRUD operations

--- a/backend/scripts/create-system-admin.ts
+++ b/backend/scripts/create-system-admin.ts
@@ -1,0 +1,56 @@
+/**
+ * One-off script to create the first system_admin user.
+ * Run from repo root: cd backend && bun run scripts/create-system-admin.ts
+ * Or: bun run backend/scripts/create-system-admin.ts (from root, may need to set cwd for .env)
+ *
+ * Requires env: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY
+ * Optional env: SYSTEM_ADMIN_EMAIL, SYSTEM_ADMIN_PASSWORD (defaults: admin@vizzocheck.local, change-me)
+ */
+import 'dotenv/config';
+import bcrypt from 'bcryptjs';
+import { createClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const email = process.env.SYSTEM_ADMIN_EMAIL || 'admin@vizzocheck.local';
+const password = process.env.SYSTEM_ADMIN_PASSWORD || 'change-me';
+
+if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+  console.error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false }
+});
+
+async function main() {
+  const { data: existing } = await supabase
+    .from('users')
+    .select('id')
+    .eq('email', email)
+    .single();
+
+  if (existing) {
+    console.log(`User ${email} already exists. Exiting.`);
+    process.exit(0);
+  }
+
+  const password_hash = await bcrypt.hash(password, 10);
+  const { error } = await supabase.from('users').insert({
+    email,
+    password_hash,
+    role: 'system_admin',
+    agency_id: null
+  });
+
+  if (error) {
+    console.error('Failed to create system_admin:', error.message);
+    process.exit(1);
+  }
+
+  console.log(`System admin created: ${email}`);
+  console.log('Change the password after first login or set SYSTEM_ADMIN_PASSWORD when running this script.');
+}
+
+main();

--- a/backend/src/controllers/agencies.ts
+++ b/backend/src/controllers/agencies.ts
@@ -3,12 +3,25 @@ import { supabase } from '../lib/supabase.js';
 import { AppError } from '../middleware/errorHandler.js';
 import { AuthRequest } from '../middleware/auth.js';
 
+export async function listAgencies(req: AuthRequest, res: Response) {
+  // Only system_admin can list all agencies (route is protected by requireRole(['system_admin']))
+  const { data: agencies, error } = await supabase
+    .from('agencies')
+    .select('*')
+    .order('name');
+
+  if (error) {
+    throw new AppError(`Failed to fetch agencies: ${error.message}`, 500);
+  }
+
+  res.json(agencies || []);
+}
+
 export async function getAgency(req: AuthRequest, res: Response) {
   const { id } = req.params;
-  const agencyId = req.agencyId;
 
-  // Ensure user can only access their own agency
-  if (id !== agencyId) {
+  // system_admin can access any agency; agency can only access their own
+  if (req.user?.role !== 'system_admin' && id !== req.agencyId) {
     throw new AppError('Forbidden', 403);
   }
 

--- a/backend/src/controllers/auth.ts
+++ b/backend/src/controllers/auth.ts
@@ -43,13 +43,13 @@ export async function register(req: Request<{}, {}, RegisterRequest>, res: Respo
     );
   }
 
-  // Create admin user
+  // Create agency user (organization that manages its stores, promoters, brands)
   const { data: user, error: userError } = await supabase
     .from('users')
     .insert({
       email,
       password_hash,
-      role: 'agency_admin',
+      role: 'agency',
       agency_id: agency.id
     })
     .select()

--- a/backend/src/controllers/upload.ts
+++ b/backend/src/controllers/upload.ts
@@ -16,10 +16,16 @@ function buildVisitPhotoKey(
   return `${agencyId}/visits/${visitId}/product-${productId}-${type}-${Date.now()}${ext}`;
 }
 
+function resolveUploadAgencyId(req: AuthRequest, resourceAgencyId: string): void {
+  if (req.user?.role === 'system_admin') return;
+  if (resourceAgencyId !== req.agencyId) {
+    throw new AppError('Forbidden', 403);
+  }
+}
+
 export async function uploadPhoto(req: AuthRequest, res: Response) {
   const file = req.file;
   const { visit_id, product_id, type } = req.body;
-  const agencyId = req.agencyId!;
 
   if (!file || !file.buffer) {
     throw new AppError('No file uploaded', 400);
@@ -32,6 +38,16 @@ export async function uploadPhoto(req: AuthRequest, res: Response) {
   if (type !== 'before' && type !== 'after') {
     throw new AppError('Type must be "before" or "after"', 400);
   }
+
+  const { data: visit } = await supabase
+    .from('visits')
+    .select('promoter:promoters(user:users!inner(agency_id))')
+    .eq('id', visit_id)
+    .single();
+  if (!visit) throw new AppError('Visit not found', 404);
+  const agencyId = (visit.promoter as any)?.user?.agency_id;
+  if (!agencyId) throw new AppError('Visit not found', 404);
+  resolveUploadAgencyId(req, agencyId);
 
   try {
     const ext = path.extname(file.originalname);
@@ -48,7 +64,6 @@ export async function uploadPhoto(req: AuthRequest, res: Response) {
 export async function uploadProductPhoto(req: AuthRequest, res: Response) {
   const file = req.file;
   const { product_id } = req.body;
-  const agencyId = req.agencyId!;
 
   if (!file || !file.buffer) {
     throw new AppError('No file uploaded', 400);
@@ -58,16 +73,17 @@ export async function uploadProductPhoto(req: AuthRequest, res: Response) {
     throw new AppError('Missing required field: product_id', 400);
   }
 
-  // Verify product belongs to agency
   const { data: product } = await supabase
     .from('products')
     .select('id, brands!inner(agency_id)')
     .eq('id', product_id)
     .single();
 
-  if (!product || (product.brands as any).agency_id !== agencyId) {
+  if (!product) {
     throw new AppError('Product not found', 404);
   }
+  const agencyId = (product.brands as any).agency_id;
+  resolveUploadAgencyId(req, agencyId);
 
   try {
     const ext = path.extname(file.originalname);
@@ -90,7 +106,6 @@ export async function uploadProductPhoto(req: AuthRequest, res: Response) {
 export async function uploadBrandLogo(req: AuthRequest, res: Response) {
   const file = req.file;
   const { brand_id } = req.body;
-  const agencyId = req.agencyId!;
 
   if (!file || !file.buffer) {
     throw new AppError('No file uploaded', 400);
@@ -100,16 +115,17 @@ export async function uploadBrandLogo(req: AuthRequest, res: Response) {
     throw new AppError('Missing required field: brand_id', 400);
   }
 
-  // Verify brand belongs to agency
   const { data: brand } = await supabase
     .from('brands')
     .select('id, agency_id')
     .eq('id', brand_id)
     .single();
 
-  if (!brand || brand.agency_id !== agencyId) {
+  if (!brand) {
     throw new AppError('Brand not found', 404);
   }
+  resolveUploadAgencyId(req, brand.agency_id);
+  const agencyId = brand.agency_id;
 
   try {
     const ext = path.extname(file.originalname);
@@ -132,7 +148,6 @@ export async function uploadBrandLogo(req: AuthRequest, res: Response) {
 export async function uploadStoreLogo(req: AuthRequest, res: Response) {
   const file = req.file;
   const { store_id } = req.body;
-  const agencyId = req.agencyId!;
 
   if (!file || !file.buffer) {
     throw new AppError('No file uploaded', 400);
@@ -142,16 +157,17 @@ export async function uploadStoreLogo(req: AuthRequest, res: Response) {
     throw new AppError('Missing required field: store_id', 400);
   }
 
-  // Verify store belongs to agency
   const { data: store } = await supabase
     .from('stores')
     .select('id, agency_id')
     .eq('id', store_id)
     .single();
 
-  if (!store || store.agency_id !== agencyId) {
+  if (!store) {
     throw new AppError('Store not found', 404);
   }
+  resolveUploadAgencyId(req, store.agency_id);
+  const agencyId = store.agency_id;
 
   try {
     const ext = path.extname(file.originalname);
@@ -174,7 +190,6 @@ export async function uploadStoreLogo(req: AuthRequest, res: Response) {
 export async function uploadPromoterPhoto(req: AuthRequest, res: Response) {
   const file = req.file;
   const { promoter_id } = req.body;
-  const agencyId = req.agencyId!;
 
   if (!file || !file.buffer) {
     throw new AppError('No file uploaded', 400);
@@ -184,27 +199,17 @@ export async function uploadPromoterPhoto(req: AuthRequest, res: Response) {
     throw new AppError('Missing required field: promoter_id', 400);
   }
 
-  // Verify promoter belongs to agency
-  const { data: users } = await supabase
-    .from('users')
-    .select('id')
-    .eq('agency_id', agencyId);
-
-  if (!users || users.length === 0) {
-    throw new AppError('Promoter not found', 404);
-  }
-
-  const userIds = users.map(u => u.id);
   const { data: promoter } = await supabase
     .from('promoters')
-    .select('id, user_id')
+    .select('id, user:users!inner(agency_id)')
     .eq('id', promoter_id)
-    .in('user_id', userIds)
     .single();
 
   if (!promoter) {
     throw new AppError('Promoter not found', 404);
   }
+  const agencyId = (promoter.user as any).agency_id;
+  resolveUploadAgencyId(req, agencyId);
 
   try {
     const ext = path.extname(file.originalname);

--- a/backend/src/routes/agencies.ts
+++ b/backend/src/routes/agencies.ts
@@ -1,9 +1,10 @@
 import express from 'express';
-import { getAgency } from '../controllers/agencies.js';
-import { authenticate } from '../middleware/auth.js';
+import { listAgencies, getAgency } from '../controllers/agencies.js';
+import { authenticate, requireRole } from '../middleware/auth.js';
 
 const router = express.Router();
 
-router.get('/:id', authenticate, getAgency);
+router.get('/', authenticate, requireRole(['system_admin']), listAgencies);
+router.get('/:id', authenticate, requireRole(['agency', 'system_admin']), getAgency);
 
 export default router;

--- a/backend/src/routes/allocations.ts
+++ b/backend/src/routes/allocations.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { authenticate } from '../middleware/auth.js';
+import { authenticate, requireRole } from '../middleware/auth.js';
 import {
   listAllocations,
   getAllocation,
@@ -11,8 +11,8 @@ import {
 
 const router = express.Router();
 
-// All routes require authentication
 router.use(authenticate);
+router.use(requireRole(['agency', 'system_admin']));
 
 router.get('/', listAllocations);
 router.get('/suggestions/:promoterId/:brandId/:storeId', getSuggestions);

--- a/backend/src/routes/brands.ts
+++ b/backend/src/routes/brands.ts
@@ -9,19 +9,19 @@ import {
   deleteProduct,
   getAuthorizedBrandsForStore
 } from '../controllers/brands.js';
-import { authenticate } from '../middleware/auth.js';
+import { authenticate, requireRole } from '../middleware/auth.js';
 
 const router = express.Router();
 
 router.use(authenticate);
 
-router.get('/', listBrands);
-router.post('/', createBrand);
+router.get('/', requireRole(['agency', 'system_admin']), listBrands);
+router.post('/', requireRole(['agency', 'system_admin']), createBrand);
 router.get('/authorized/:storeId', getAuthorizedBrandsForStore);
-router.get('/:id', getBrand);
-router.put('/:id', updateBrand);
-router.post('/:id/products', addProduct);
-router.put('/products/:id', updateProduct);
-router.delete('/products/:id', deleteProduct);
+router.get('/:id', requireRole(['agency', 'system_admin']), getBrand);
+router.put('/:id', requireRole(['agency', 'system_admin']), updateBrand);
+router.post('/:id/products', requireRole(['agency', 'system_admin']), addProduct);
+router.put('/products/:id', requireRole(['agency', 'system_admin']), updateProduct);
+router.delete('/products/:id', requireRole(['agency', 'system_admin']), deleteProduct);
 
 export default router;

--- a/backend/src/routes/promoters.ts
+++ b/backend/src/routes/promoters.ts
@@ -18,10 +18,10 @@ router.use(authenticate);
 router.get('/earnings/my', getMyEarnings);
 
 // Admin only routes
-router.get('/', requireRole(['agency_admin']), listPromoters);
-router.post('/', requireRole(['agency_admin']), createPromoter);
+router.get('/', requireRole(['agency', 'system_admin']), listPromoters);
+router.post('/', requireRole(['agency', 'system_admin']), createPromoter);
 router.get('/:id', getPromoter);
-router.put('/:id', requireRole(['agency_admin']), updatePromoter);
-router.patch('/:id/active', requireRole(['agency_admin']), toggleActive);
+router.put('/:id', requireRole(['agency', 'system_admin']), updatePromoter);
+router.patch('/:id/active', requireRole(['agency', 'system_admin']), toggleActive);
 
 export default router;

--- a/backend/src/routes/reports.ts
+++ b/backend/src/routes/reports.ts
@@ -15,7 +15,7 @@ import { authenticate, requireRole } from '../middleware/auth.js';
 const router = express.Router();
 
 router.use(authenticate);
-router.use(requireRole(['agency_admin']));
+router.use(requireRole(['agency', 'system_admin']));
 
 router.get('/financial', getFinancialReport);
 router.get('/financial/export', exportFinancialReport);

--- a/backend/src/routes/stores.ts
+++ b/backend/src/routes/stores.ts
@@ -6,16 +6,16 @@ import {
   updateStore,
   getAuthorizedStores
 } from '../controllers/stores.js';
-import { authenticate } from '../middleware/auth.js';
+import { authenticate, requireRole } from '../middleware/auth.js';
 
 const router = express.Router();
 
 router.use(authenticate);
 
-router.get('/', listStores);
-router.post('/', createStore);
+router.get('/', requireRole(['agency', 'system_admin']), listStores);
+router.post('/', requireRole(['agency', 'system_admin']), createStore);
 router.get('/authorized', getAuthorizedStores);
-router.get('/:id', getStore);
-router.put('/:id', updateStore);
+router.get('/:id', requireRole(['agency', 'system_admin']), getStore);
+router.put('/:id', requireRole(['agency', 'system_admin']), updateStore);
 
 export default router;

--- a/backend/src/routes/visits.ts
+++ b/backend/src/routes/visits.ts
@@ -13,12 +13,12 @@ const router = express.Router();
 
 router.use(authenticate);
 
-router.get('/', listVisits);
+router.get('/', requireRole(['agency', 'system_admin']), listVisits);
 router.post('/', createVisit);
 router.get('/my-visits', getMyVisits);
 // More specific routes must come before generic :id routes
-router.put('/:visitId/products/:productId/photos', updateVisitProductPhotos);
-router.get('/:id', getVisit);
-router.put('/:id', requireRole(['agency_admin']), updateVisit);
+router.put('/:visitId/products/:productId/photos', requireRole(['agency', 'system_admin']), updateVisitProductPhotos);
+router.get('/:id', requireRole(['agency', 'system_admin']), getVisit);
+router.put('/:id', requireRole(['agency', 'system_admin']), updateVisit);
 
 export default router;

--- a/docs/roles-and-scope.md
+++ b/docs/roles-and-scope.md
@@ -1,0 +1,56 @@
+# Papéis e escopo de acesso
+
+Este documento descreve o modelo de papéis (admin geral vs agência) e o escopo de dados no VizzoCheck.
+
+## Admin geral (system_admin)
+
+- **Definição:** Um ou mais usuários com acesso a **todas** as agências do sistema (visão e gestão global).
+- **Identificação:** Usuário com `role = 'system_admin'` e `agency_id = NULL`.
+- **Cadastro:** Não há cadastro público de admin geral; o primeiro usuário system_admin é criado via seed ou migration (não exposto no registro).
+- **Uso no sistema:** O admin geral faz login na mesma tela de login; no painel, vê o item **Agências** no menu, seleciona uma agência para definir o contexto e então acessa dashboard, lojas, promotores, marcas, visitas, alocações e relatórios **no escopo da agência selecionada**. Pode trocar de agência a qualquer momento.
+- **API:** Nas requisições, o escopo é informado via parâmetro `agency_id` (query ou body), quando aplicável.
+
+## Agência (agency)
+
+- **Definição:** A organização que faz login e tem escopo restrito aos **seus** dados: lojas (cadastradas por ela), e no futuro promotores e marcas vinculados por **convite**.
+- **Identificação:** Usuário com `role = 'agency'` e `agency_id` preenchido (referência à tabela `agencies`).
+- **Cadastro:** Via tela de registro: cria-se a agência e o primeiro usuário com role `agency` (não mais "admin da agência").
+- **Lojas:** Responsabilidade exclusiva da agência — cada agência cadastra apenas **suas** lojas de atuação.
+- **Promotores e marcas:** Hoje a agência vê todos os promotores e marcas vinculados a ela. Em histórias futuras, promotores e marcas entrarão no escopo da agência **somente via fluxo de convite** (convite da agência ou convite aceito pela agência).
+
+## Promoter (promoter)
+
+- Usuário que atua como promotor de visitas; está vinculado a uma agência (`users.agency_id`) e acessa o painel do promotor (visitas, ganhos, etc.), não o painel admin/agência.
+
+## Resumo
+
+| Papel         | agency_id   | Escopo de dados |
+|---------------|-------------|------------------|
+| system_admin  | NULL        | Todas as agências (contexto escolhido no painel) |
+| agency        | obrigatório | Apenas sua agência (lojas próprias; promotores/marcas por convite no futuro) |
+| promoter      | obrigatório | Dados do promotor (visitas, ganhos) |
+
+## Criação do primeiro admin geral
+
+Não há tela de cadastro público para admin geral. Para criar o primeiro usuário `system_admin`:
+
+1. **Via script (recomendado):** Use o script em `backend/scripts/create-system-admin.ts` (se existir) ou execute no Node/Bun com bcrypt para gerar um `password_hash` e inserir em `users` com `role = 'system_admin'` e `agency_id = NULL`.
+2. **Via SQL (após gerar o hash):** Inserir manualmente em `users` com um hash bcrypt da senha escolhida (ex.: gerar com `bcrypt.hashSync('sua_senha', 10)` em um script one-off).
+
+Exemplo de script one-off (rodar uma vez a partir da raiz do monorepo):
+
+```ts
+// create-system-admin.ts
+import bcrypt from 'bcryptjs';
+import { createClient } from '@supabase/supabase-js';
+const supabase = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE_KEY!);
+const email = process.env.SYSTEM_ADMIN_EMAIL || 'admin@vizzocheck.local';
+const password = process.env.SYSTEM_ADMIN_PASSWORD || 'change-me';
+const hash = await bcrypt.hash(password, 10);
+await supabase.from('users').insert({ email, password_hash: hash, role: 'system_admin', agency_id: null });
+```
+
+## Referências
+
+- Issue [#1](https://github.com/vizzo-check/vizzo-check/issues/1) — Admin geral vs Agência
+- Migration `010_system_admin_and_agency_role.sql` — schema e migração de `agency_admin` para `agency` + `system_admin`

--- a/frontend/app/admin/agencies/page.tsx
+++ b/frontend/app/admin/agencies/page.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/lib/auth';
+import { api } from '@/lib/api';
+import Link from 'next/link';
+
+export default function AdminAgenciesPage() {
+  const { user, loading: authLoading, selectedAgencyId, setSelectedAgencyId } = useAuth();
+  const router = useRouter();
+  const [agencies, setAgencies] = useState<{ id: string; name: string }[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!authLoading && !user) {
+      router.push('/admin/login');
+      return;
+    }
+    if (user && user.role !== 'system_admin') {
+      router.push('/admin/dashboard');
+      return;
+    }
+  }, [user, authLoading, router]);
+
+  useEffect(() => {
+    if (user?.role === 'system_admin') {
+      api
+        .listAgencies()
+        .then((data: any) => setAgencies(Array.isArray(data) ? data : []))
+        .catch(() => setAgencies([]))
+        .finally(() => setLoading(false));
+    }
+  }, [user?.role]);
+
+  if (authLoading || (user && user.role !== 'system_admin')) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">Agências</h1>
+        <p className="mt-1 text-gray-600">
+          Selecione uma agência para visualizar e gerenciar seus dados no painel.
+        </p>
+      </div>
+
+      {loading ? (
+        <p className="text-gray-500">Carregando...</p>
+      ) : agencies.length === 0 ? (
+        <p className="text-gray-500">Nenhuma agência cadastrada.</p>
+      ) : (
+        <ul className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {agencies.map((agency) => (
+            <li key={agency.id}>
+              <button
+                type="button"
+                onClick={() => {
+                  setSelectedAgencyId(agency.id);
+                  router.push('/admin/dashboard');
+                }}
+                className={`w-full rounded-lg border p-4 text-left shadow-sm transition ${
+                  selectedAgencyId === agency.id
+                    ? 'border-blue-600 bg-blue-50 ring-1 ring-blue-600'
+                    : 'border-gray-200 bg-white hover:border-gray-300 hover:bg-gray-50'
+                }`}
+              >
+                <span className="font-medium text-gray-900">{agency.name}</span>
+                {selectedAgencyId === agency.id && (
+                  <span className="ml-2 text-sm text-blue-600">(selecionada)</span>
+                )}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <p className="text-sm text-gray-500">
+        <Link href="/admin/dashboard" className="text-blue-600 hover:underline">
+          Voltar ao dashboard
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/frontend/app/admin/visits/[id]/page.tsx
+++ b/frontend/app/admin/visits/[id]/page.tsx
@@ -20,7 +20,7 @@ export default function VisitDetailPage() {
   const [notes, setNotes] = useState('');
 
   useEffect(() => {
-    if (!authLoading && (!user || user.role !== 'agency_admin')) {
+    if (!authLoading && (!user || user.role === 'promoter')) {
       router.push('/admin/login');
     }
   }, [user, authLoading, router]);

--- a/frontend/components/AdminSidebar.tsx
+++ b/frontend/components/AdminSidebar.tsx
@@ -13,11 +13,22 @@ interface MenuItem {
   badge?: number;
 }
 
+const agenciesMenuItem: MenuItem = {
+  title: 'Agências',
+  href: '/admin/agencies',
+  icon: (
+    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
+    </svg>
+  )
+};
+
 export default function AdminSidebar() {
   const [isOpen, setIsOpen] = useState(false);
   const pathname = usePathname();
   const { user, logout } = useAuth();
   const router = useRouter();
+  const isSystemAdmin = user?.role === 'system_admin';
 
   function handleLogout() {
     logout();
@@ -25,6 +36,7 @@ export default function AdminSidebar() {
   }
 
   const menuItems: MenuItem[] = [
+    ...(isSystemAdmin ? [agenciesMenuItem] : []),
     {
       title: 'Dashboard',
       href: '/admin/dashboard',
@@ -92,6 +104,9 @@ export default function AdminSidebar() {
 
   const isActive = (href: string) => {
     if (href === '/admin/dashboard') {
+      return pathname === href;
+    }
+    if (href === '/admin/agencies') {
       return pathname === href;
     }
     return pathname.startsWith(href);
@@ -223,7 +238,9 @@ export default function AdminSidebar() {
         {/* User section */}
         <div className="p-4 border-t border-gray-700">
           <div className="mb-3 px-4 py-2 rounded-lg bg-gray-800/50">
-            <p className="text-xs text-gray-400 mb-1">Usuário</p>
+            <p className="text-xs text-gray-400 mb-1">
+              {isSystemAdmin ? 'Admin geral' : 'Agência'}
+            </p>
             <p className="text-sm font-medium text-white truncate">{user?.email}</p>
           </div>
           <button

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,11 +1,11 @@
 // User types
-export type UserRole = 'agency_admin' | 'promoter';
+export type UserRole = 'system_admin' | 'agency' | 'promoter';
 
 export interface User {
   id: string;
   email: string;
   role: UserRole;
-  agency_id: string;
+  agency_id: string | null;
   created_at: string;
 }
 

--- a/supabase/migrations/010_system_admin_and_agency_role.sql
+++ b/supabase/migrations/010_system_admin_and_agency_role.sql
@@ -1,0 +1,15 @@
+-- Add new role values to user_role enum
+ALTER TYPE user_role ADD VALUE IF NOT EXISTS 'system_admin';
+ALTER TYPE user_role ADD VALUE IF NOT EXISTS 'agency';
+
+-- Migrate existing agency_admin users to agency
+UPDATE users SET role = 'agency' WHERE role = 'agency_admin';
+
+-- Allow agency_id to be NULL for system_admin
+ALTER TABLE users ALTER COLUMN agency_id DROP NOT NULL;
+
+-- Ensure: system_admin has no agency; other roles must have agency_id
+ALTER TABLE users ADD CONSTRAINT users_role_agency_check CHECK (
+  (role = 'system_admin' AND agency_id IS NULL) OR
+  (role <> 'system_admin' AND agency_id IS NOT NULL)
+);


### PR DESCRIPTION
Implementa a distinção entre **admin geral** (acesso cross-agency) e **agência** (escopo restrito às suas lojas e, no futuro, promotores/marcas por convite).

## Resumo das mudanças

### Schema e tipos
- **Migration 010:** novos valores no enum user_role: system_admin e agency; migração de agency_admin para agency; users.agency_id opcional; CHECK para consistência role/agency_id.
- **Shared:** UserRole = system_admin | agency | promoter; User.agency_id opcional.

### Backend
- **Auth:** registro cria usuário com role agency; login retorna agency_id null para system_admin; JWT com agencyId opcional.
- **Middleware:** getEffectiveAgencyId(req, queryAgencyId); requireRole(['agency', 'system_admin']) nas rotas de gestão.
- **Agencies:** listAgencies (GET /api/agencies) só para system_admin; getAgency permite system_admin acessar qualquer id.
- **Stores, brands, promoters, visits, reports, allocations, upload:** escopo por effectiveAgencyId; system_admin usa agency_id (query/body).
- **Script:** backend/scripts/create-system-admin.ts para criar o primeiro usuário admin geral.

### Frontend
- **Auth:** contexto com selectedAgencyId, effectiveAgencyId; tipos atualizados.
- **API:** listAgencies(), getAgency(id); métodos de listagem/relatórios aceitam agencyId para system_admin.
- **Sidebar:** item Agências para system_admin; rótulo Admin geral vs Agência.
- **Página /admin/agencies:** lista agências e permite selecionar uma para definir o contexto.
- **Dashboard, visits, stores, brands, promoters, allocations, financial:** usam effectiveAgencyId nas chamadas; mensagem para system_admin sem agência selecionada; criação de recursos envia agency_id quando aplicável.
- **Acesso:** redirecionamento apenas para promoter (agency e system_admin acessam o painel admin).

### Documentação
- **docs/roles-and-scope.md:** definição de papéis, escopo e como criar o primeiro admin geral.
- **IMPLEMENTATION_STATUS.md:** seção sobre Admin geral vs Agência e link para a doc.

Closes #1